### PR TITLE
stop fetching nobin for s6 overlay and install per architecture version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
 FROM easypi/alpine-arm:3.4
 MAINTAINER sparklyballs
 
-# set version for s6 overlay
-ARG OVERLAY_VERSION="v1.18.1.0"
+# set version for s6 overlay
+ARG OVERLAY_VERSION="v1.18.1.3"
+ARG OVERLAY_ARCH="armhf"
+ARG OVERLAY_URL="https://github.com/just-containers/s6-overlay/releases/download"
+ARG OVERLAY_WWW="${OVERLAY_URL}"/"${OVERLAY_VERSION}"/s6-overlay-"${OVERLAY_ARCH}".tar.gz
 
 # set some environment variables
 ENV PS1="$(whoami)@$(hostname):$(pwd)$ " \
 HOME="/root" \
 TERM="xterm"
 
-# add packages
+# add packages
 RUN \
  apk add --no-cache --virtual=build-dependencies \
 	curl \
@@ -17,8 +20,6 @@ RUN \
 
  apk add --no-cache \
 	bash \
-	s6 \
-	s6-portable-utils \
 	tzdata && \
 
 apk add --no-cache --repository http://nl.alpinelinux.org/alpine/edge/testing \
@@ -26,25 +27,25 @@ apk add --no-cache --repository http://nl.alpinelinux.org/alpine/edge/testing \
 
 # add s6 overlay
  curl -o \
-	/tmp/s6-overlay.tar.gz -L \
-	https://github.com/just-containers/s6-overlay/releases/download/"${OVERLAY_VERSION}"/s6-overlay-nobin.tar.gz && \
-	tar xvfz /tmp/s6-overlay.tar.gz -C / && \
+ /tmp/s6-overlay.tar.gz -L \
+	"${OVERLAY_WWW}" && \
+ tar xvfz /tmp/s6-overlay.tar.gz -C / && \
 
 # clean up
  apk del --purge \
 	build-dependencies && \
  rm -rf /var/cache/apk/* /tmp/*
 
-# create abc user
+# create abc user
 RUN \
 	groupmod -g 1000 users && \
 	useradd -u 911 -U -d /config -s /bin/false abc && \
 	usermod -G users abc && \
 
-# create some folders
+# create some folders
 	mkdir -p /config /app /defaults
 
-# add local files
+# add local files
 COPY root/ /
 
 ENTRYPOINT ["/init"]


### PR DESCRIPTION
Drop using nobin version of S6 and then installing packages.....
Use arch specific overlay, set by variable, easier tranistion to armhf and smaller build.
